### PR TITLE
Advanced creation of repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 # Rmodel
 
+* [Installation](#installation)
+* [Usage](#usage)
+  * [CRUD](#crud)
+  * [Scopes](#scopes)
+  * [Timestamps](#timestamps)
+  * [Sugar Methods](#sugar-methods)
+
 Rmodel is an ORM library, which tends to follow the SOLID principles.
 
 **Currently works with MongoDB only.**

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
   * [CRUD](#crud)
   * [Scopes](#scopes)
   * [Timestamps](#timestamps)
-  * [Sugar Methods](#sugar-methods)
+  * [Sugar methods](#sugar-methods)
+  * [Advanced creation of repository](#advanced-creation-of-repository)
 
 Rmodel is an ORM library, which tends to follow the SOLID principles.
 
@@ -204,6 +205,28 @@ If the object has no not-nil id then it gets inserted. Otherwise it gets updated
 
 The `find!` method works like the simple `find`
 , but instead of nil it raises the Rmodel::NotFound error.
+
+### Advanced creation of repository
+
+```ruby
+require 'rmodel'
+
+class Thing
+  attr_accessor :id, :name
+end
+
+class ThingRepository < Rmodel::Mongo::Repository
+end
+
+client = Mongo::Client.new([ 'localhost:27017' ], database: 'test')
+collection = :things
+factory = Rmodel::Mongo::SimpleFactory.new(Thing, :name)
+
+repo = ThingRepository.new(client, collection, factory)
+repo.find(1)
+```
+
+The `factory` is an object, which has 2 methods: `#fromHash(hash)` and `#toHash(object)`.
 
 ## Contributing
 

--- a/examples/advanced_creation_of_repository.rb
+++ b/examples/advanced_creation_of_repository.rb
@@ -1,0 +1,15 @@
+require 'rmodel'
+
+class Thing
+  attr_accessor :id, :name
+end
+
+class ThingRepository < Rmodel::Mongo::Repository
+end
+
+client = Mongo::Client.new([ 'localhost:27017' ], database: 'test')
+collection = :things
+factory = Rmodel::Mongo::SimpleFactory.new(Thing, :name)
+
+repo = ThingRepository.new(client, collection, factory)
+p repo.find(1)

--- a/lib/rmodel/mongo/repository.rb
+++ b/lib/rmodel/mongo/repository.rb
@@ -10,15 +10,15 @@ module Rmodel::Mongo
     prepend RepositoryExt::Timestampable
     include RepositoryExt::Sugarable
 
-    def initialize
-      @client = Rmodel.setup.establish_mongo_client(self.class.client_name || :default) or
+    def initialize(client = nil, collection = nil, factory = nil)
+      @client = client || Rmodel.setup.establish_mongo_client(self.class.client_name || :default) or
                 raise ArgumentError.new('Client driver is not setup')
 
-      @collection = self.class.setting_collection ||
+      @collection = collection || self.class.setting_collection ||
                     self.class.collection_by_convention or
                     raise ArgumentError.new('Collection can not be guessed')
 
-      @factory = self.class.setting_factory or
+      @factory = factory || self.class.setting_factory or
                  raise ArgumentError.new('Factory can not be guessed')
     end
 

--- a/spec/rmodel/mongo/repository_crud_spec.rb
+++ b/spec/rmodel/mongo/repository_crud_spec.rb
@@ -3,16 +3,11 @@ RSpec.describe Rmodel::Mongo::Repository do
 
   before do
     stub_const('User', Struct.new(:id, :name, :email))
-    stub_const('UserRepository', Class.new(Rmodel::Mongo::Repository) {
-      simple_factory User, :name, :email
-    })
-    Rmodel.setup do
-      client :default, hosts: [ 'localhost' ], database: 'rmodel_test'
-    end
+    stub_const('UserRepository', Class.new(Rmodel::Mongo::Repository))
   end
 
   let(:factory) { Rmodel::Mongo::SimpleFactory.new(User, :name, :email) }
-  subject(:repo) { UserRepository.new }
+  subject(:repo) { UserRepository.new(mongo_session, :users, factory) }
 
   describe '#find' do
     context 'when an existent id is given' do

--- a/spec/rmodel/mongo/repository_ext/queryable_spec.rb
+++ b/spec/rmodel/mongo/repository_ext/queryable_spec.rb
@@ -2,16 +2,12 @@ RSpec.describe Rmodel::Mongo::Repository do
   include_context 'clean Mongo database'
 
   before do
-    Rmodel.setup do
-      client :default, hosts: [ 'localhost' ], database: 'rmodel_test'
-    end
     stub_const('Thing', Struct.new(:id, :a, :b))
-    stub_const('ThingRepository', Class.new(Rmodel::Mongo::Repository) {
-      simple_factory Thing, :a, :b
-    })
+    stub_const('ThingRepository', Class.new(Rmodel::Mongo::Repository))
   end
 
-  let(:repo) { ThingRepository.new }
+  let(:factory) { Rmodel::Mongo::SimpleFactory.new(Thing, :a, :b) }
+  let(:repo) { ThingRepository.new(mongo_session, :things, factory) }
 
   before do
     repo.insert(Thing.new(nil, 2, 3))

--- a/spec/rmodel/mongo/repository_ext/sugarable_spec.rb
+++ b/spec/rmodel/mongo/repository_ext/sugarable_spec.rb
@@ -4,12 +4,11 @@ RSpec.describe Rmodel::Mongo::Repository do
   describe Rmodel::Mongo::RepositoryExt::Sugarable do
     before do
       stub_const('Thing', Struct.new(:id, :name))
-      stub_const('ThingRepository', Class.new(Rmodel::Mongo::Repository) {
-        simple_factory Thing, :name
-      })
+      stub_const('ThingRepository', Class.new(Rmodel::Mongo::Repository))
     end
 
-    subject(:repo) { ThingRepository.new }
+    let(:factory) { Rmodel::Mongo::SimpleFactory.new(Thing, :name) }
+    subject(:repo) { ThingRepository.new(mongo_session, :things, factory) }
 
     describe '#find!' do
       context 'when an existent id is given' do

--- a/spec/rmodel/mongo/repository_ext/timestampable_spec.rb
+++ b/spec/rmodel/mongo/repository_ext/timestampable_spec.rb
@@ -1,14 +1,18 @@
 RSpec.describe Rmodel::Mongo::Repository do
+  include_context 'clean Mongo database'
+
   describe Rmodel::Mongo::RepositoryExt::Timestampable do
-    subject(:repo) { ThingRepository.new }
+    before do
+      stub_const('ThingRepository', Class.new(Rmodel::Mongo::Repository))
+    end
 
     context 'when the entity object has attributes created_at and updated_at' do
       before do
         stub_const('Thing', Struct.new(:id, :name, :created_at, :updated_at))
-        stub_const('ThingRepository', Class.new(Rmodel::Mongo::Repository) {
-          simple_factory Thing, :name, :created_at, :updated_at
-        })
       end
+
+      let(:factory) { Rmodel::Mongo::SimpleFactory.new(Thing, :name, :created_at, :updated_at) }
+      subject(:repo) { ThingRepository.new(mongo_session, :things, factory) }
 
       context 'when we insert(object)' do
         context 'and the object.created_at is already set' do
@@ -46,10 +50,10 @@ RSpec.describe Rmodel::Mongo::Repository do
     context 'when the entity has no attributes :created_at and updated_at' do
       before do
         stub_const('Thing', Struct.new(:id, :name))
-        stub_const('ThingRepository', Class.new(Rmodel::Mongo::Repository) {
-          simple_factory Thing, :name
-        })
       end
+
+      let(:factory) { Rmodel::Mongo::SimpleFactory.new(Thing, :name) }
+      subject(:repo) { ThingRepository.new(mongo_session, :things, factory) }
       let(:thing) { Thing.new(nil, 'chair') }
 
       context 'when we insert(object)' do

--- a/spec/rmodel/mongo/repository_initialize_spec.rb
+++ b/spec/rmodel/mongo/repository_initialize_spec.rb
@@ -1,15 +1,13 @@
 RSpec.describe Rmodel::Mongo::Repository do
   before do
-    Rmodel.setup.clear
     stub_const('User', Struct.new(:id, :name, :email))
   end
 
-  subject { UserRepository.new }
-
   describe '.client(name)' do
-    before do
-      Rmodel::Setup.send :public, :client
-    end
+    subject { UserRepository.new }
+
+    before { Rmodel::Setup.send :public, :client }
+
     context 'when it is called with an existent name' do
       before do
         Rmodel.setup do
@@ -22,6 +20,7 @@ RSpec.describe Rmodel::Mongo::Repository do
           attr_reader :client
         })
       end
+      after { Rmodel::setup.clear }
 
       it 'sets the appropriate #client' do
         expect(subject.client).to be_an_instance_of Mongo::Client
@@ -56,6 +55,7 @@ RSpec.describe Rmodel::Mongo::Repository do
             client :default, { hosts: [ 'localhost' ] }
           end
         end
+        after { Rmodel::setup.clear }
 
         it 'sets #client to be default' do
           expect(subject.client).to be_an_instance_of Mongo::Client
@@ -71,11 +71,14 @@ RSpec.describe Rmodel::Mongo::Repository do
   end
 
   describe '.collection(name)' do
+    subject { UserRepository.new }
+
     before do
       Rmodel.setup do
         client :default, { hosts: [ 'localhost' ] }
       end
     end
+    after { Rmodel::setup.clear }
 
     context 'when the :people collection is given' do
       before do
@@ -106,11 +109,14 @@ RSpec.describe Rmodel::Mongo::Repository do
   end
 
   describe '.simple_factory(klass, attribute1, attribute2, ...)' do
+    subject { UserRepository.new }
+
     before do
       Rmodel.setup do
         client :default, { hosts: [ 'localhost' ] }
       end
     end
+    after { Rmodel::setup.clear }
 
     context 'when it is called' do
       before do
@@ -134,6 +140,21 @@ RSpec.describe Rmodel::Mongo::Repository do
         expect {
           UserRepository.new
         }.to raise_error ArgumentError
+      end
+    end
+  end
+
+  describe '#initialize(client, collection, factory)' do
+    context 'when all constructor arguments are passed' do
+      before do
+        stub_const('UserRepository', Class.new(Rmodel::Mongo::Repository))
+      end
+      let(:factory) { Rmodel::Mongo::SimpleFactory.new(User, :name, :email) }
+
+      it 'works!' do
+        expect {
+          UserRepository.new(Object.new, :users, factory)
+        }.not_to raise_error
       end
     end
   end

--- a/spec/rmodel/mongo/simple_factory_spec.rb
+++ b/spec/rmodel/mongo/simple_factory_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Rmodel::Mongo::SimpleFactory do
   context 'when the User(id, name, email) class is defined' do
     before { stub_const('User', Struct.new(:id, :name, :email)) }
 
-    subject(:factory) { Rmodel::Mongo::SimpleFactory.new(User, :name, :email) }
+    subject(:factory) { described_class.new(User, :name, :email) }
 
     describe '#fromHash' do
       context 'when the hash with _id, name and email is given' do


### PR DESCRIPTION
Make possible to create a repo passing all required arguments to its constructor.

```ruby
require 'rmodel'

class Thing
  attr_accessor :id, :name
end

class ThingRepository < Rmodel::Mongo::Repository
end

client = Mongo::Client.new([ 'localhost:27017' ], database: 'test')
collection = :things
factory = Rmodel::Mongo::SimpleFactory.new(Thing, :name)

repo = ThingRepository.new(client, collection, factory)
repo.find(1)
```

The `factory` is an object, which has 2 methods: `#fromHash(hash)` and `#toHash(object)`.