### PR TITLE
Inline scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,13 @@ repo.query.have_email.destroy # extract users and run repo.destroy for the each 
 p repo.query.count # 0
 ```
 
+It's possible to use so-called **inline** scopes. They aren't defined within
+the repository, but are written directly in the query.
+
+```ruby
+repo.query.scope { where(age: { '$gte' => 20 }) }.count
+```
+
 ### Timestamps
 
 Here is an example how to track the time, when the entity was created and updated.

--- a/lib/rmodel/base/query_builder.rb
+++ b/lib/rmodel/base/query_builder.rb
@@ -20,6 +20,11 @@ module Rmodel::Base
       @repo.destroy_by_query(@query)
     end
 
+    def scope(&block)
+      new_query = @query.instance_eval(&block)
+      self.class.new(@repo, new_query)
+    end
+
     def self.define_scope(name, &block)
       define_method name do |*args|
         new_query = @query.instance_exec(*args, &block)

--- a/spec/rmodel/mongo/repository_ext/queryable_spec.rb
+++ b/spec/rmodel/mongo/repository_ext/queryable_spec.rb
@@ -76,6 +76,13 @@ RSpec.describe Rmodel::Mongo::Repository do
   end
 
   describe '.query' do
+    describe '#scope(&block)' do
+      it 'creates an inline scope and returns a new query' do
+        count = repo.query.scope { where(a: 2) }.count
+        expect(count).to eq 2
+      end
+    end
+
     describe '#remove' do
       context 'when no scope is given' do
         it 'removes all objects' do

--- a/spec/rmodel/mongo/repository_ext/queryable_spec.rb
+++ b/spec/rmodel/mongo/repository_ext/queryable_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe Rmodel::Mongo::Repository do
   end
 
   let(:factory) { Rmodel::Mongo::SimpleFactory.new(Thing, :a, :b) }
-  let(:repo) { ThingRepository.new(mongo_session, :things, factory) }
+  subject { ThingRepository.new(mongo_session, :things, factory) }
 
   before do
-    repo.insert(Thing.new(nil, 2, 3))
-    repo.insert(Thing.new(nil, 2, 4))
-    repo.insert(Thing.new(nil, 5, 6))
+    subject.insert(Thing.new(nil, 2, 3))
+    subject.insert(Thing.new(nil, 2, 4))
+    subject.insert(Thing.new(nil, 5, 6))
   end
 
   describe '.scope' do
@@ -26,11 +26,11 @@ RSpec.describe Rmodel::Mongo::Repository do
       end
 
       it 'works!' do
-        expect(repo.query.a_equals_2.count).to eq 2
+        expect(subject.query.a_equals_2.count).to eq 2
       end
 
       it 'returns an array of instances of the appropriate class' do
-        expect(repo.query.a_equals_2.first).to be_an_instance_of Thing
+        expect(subject.query.a_equals_2.first).to be_an_instance_of Thing
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe Rmodel::Mongo::Repository do
       end
 
       it 'works!' do
-        expect(repo.query.a_equals(2).count).to eq 2
+        expect(subject.query.a_equals(2).count).to eq 2
       end
     end
 
@@ -62,14 +62,14 @@ RSpec.describe Rmodel::Mongo::Repository do
       end
 
       it 'works!' do
-        expect(repo.query.a_equals(2).b_equals(4).count).to eq 1
+        expect(subject.query.a_equals(2).b_equals(4).count).to eq 1
       end
     end
 
     context 'when an unknown scope is used' do
       it 'raises the NoMethodError' do
         expect {
-          repo.query.something
+          subject.query.something
         }.to raise_error NoMethodError
       end
     end
@@ -78,7 +78,7 @@ RSpec.describe Rmodel::Mongo::Repository do
   describe '.query' do
     describe '#scope(&block)' do
       it 'creates an inline scope and returns a new query' do
-        count = repo.query.scope { where(a: 2) }.count
+        count = subject.query.scope { where(a: 2) }.count
         expect(count).to eq 2
       end
     end
@@ -86,8 +86,8 @@ RSpec.describe Rmodel::Mongo::Repository do
     describe '#remove' do
       context 'when no scope is given' do
         it 'removes all objects' do
-          repo.query.remove
-          expect(repo.query.count).to eq 0
+          subject.query.remove
+          expect(subject.query.count).to eq 0
         end
       end
 
@@ -101,8 +101,8 @@ RSpec.describe Rmodel::Mongo::Repository do
         end
 
         it 'removes 2 objects' do
-          repo.query.a_equals_2.remove
-          expect(repo.query.count).to eq 1
+          subject.query.a_equals_2.remove
+          expect(subject.query.count).to eq 1
         end
       end
     end
@@ -110,13 +110,13 @@ RSpec.describe Rmodel::Mongo::Repository do
     describe '#destroy' do
       context 'when no scope is given' do
         it 'destroys all objects' do
-          repo.query.destroy
-          expect(repo.query.count).to eq 0
+          subject.query.destroy
+          expect(subject.query.count).to eq 0
         end
 
         it 'calls #destroy for each object' do
-          expect(repo).to receive(:destroy).exactly(3).times
-          repo.query.destroy
+          expect(subject).to receive(:destroy).exactly(3).times
+          subject.query.destroy
         end
       end
 
@@ -130,13 +130,13 @@ RSpec.describe Rmodel::Mongo::Repository do
         end
 
         it 'destroys 2 objects' do
-          repo.query.a_equals_2.destroy
-          expect(repo.query.count).to eq 1
+          subject.query.a_equals_2.destroy
+          expect(subject.query.count).to eq 1
         end
 
         it 'calls #destroy for each object' do
-          expect(repo).to receive(:destroy).exactly(2).times
-          repo.query.a_equals_2.destroy
+          expect(subject).to receive(:destroy).exactly(2).times
+          subject.query.a_equals_2.destroy
         end
       end
     end

--- a/spec/rmodel/sequel/repository_ext/queryable_spec.rb
+++ b/spec/rmodel/sequel/repository_ext/queryable_spec.rb
@@ -79,6 +79,13 @@ RSpec.describe Rmodel::Sequel::Repository do
   end
 
   describe '.query' do
+    describe '#scope(&block)' do
+      it 'creates an inline scope and returns a new query' do
+        count = subject.query.scope { where(a: 2) }.count
+        expect(count).to eq 2
+      end
+    end
+
     describe '#remove' do
       context 'when no scope is given' do
         it 'removes all objects' do


### PR DESCRIPTION
It's possible to use so-called **inline** scopes. They aren't defined within
the repository, but are written directly in the query.

```ruby
repo.query.scope { where(age: { '$gte' => 20 }) }.count
```