### PR TITLE
Add polysemantic Repository#insert

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ p userRepository.find(john.id) # #<User:0x000000037237d0 @name="John Smith" ... 
 p userRepository.find(bob.id) # nil
 ```
 
+The `insert` method is polysemantic. All options below are valid.
+
+```ruby
+repo.insert(object)
+repo.insert([ object1, object2, object3 ])
+repo.insert(object1, object2, object3)
+```
+
 ### Scopes
 
 Scopes are defined inside the repository.

--- a/lib/rmodel/base/repository.rb
+++ b/lib/rmodel/base/repository.rb
@@ -7,6 +7,22 @@ module Rmodel::Base
     include RepositoryExt::Sugarable
     include RepositoryExt::Queryable
 
+    def insert(*args)
+      if args.length == 1
+        if args.first.is_a?(Array)
+          args.first.each do |object|
+            insert_one(object)
+          end
+        else
+          insert_one(args.first)
+        end
+      else
+        args.each do |object|
+          insert_one(object)
+        end
+      end
+    end
+
     def remove(object)
       warn '#remove is deprecated, use #destroy instead'
       destroy(object)

--- a/lib/rmodel/base/repository_ext/timestampable.rb
+++ b/lib/rmodel/base/repository_ext/timestampable.rb
@@ -1,7 +1,7 @@
 module Rmodel::Base
   module RepositoryExt
     module Timestampable
-      def insert(object)
+      def insert_one(object)
         if object.respond_to?(:created_at) && object.respond_to?(:created_at=)
           object.created_at ||= Time.now
         end

--- a/lib/rmodel/mongo/repository.rb
+++ b/lib/rmodel/mongo/repository.rb
@@ -22,7 +22,7 @@ module Rmodel::Mongo
       result && @factory.to_object(result)
     end
 
-    def insert(object)
+    def insert_one(object)
       object.id ||= BSON::ObjectId.new
       @client[@collection].insert_one(@factory.to_hash(object, true))
     end

--- a/lib/rmodel/sequel/repository.rb
+++ b/lib/rmodel/sequel/repository.rb
@@ -22,7 +22,7 @@ module Rmodel::Sequel
       result && @factory.to_object(result)
     end
 
-    def insert(object)
+    def insert_one(object)
       id = @client[@table].insert(@factory.to_hash(object, true))
       object.id ||= id
     end

--- a/spec/shared/repository_ext/crud.rb
+++ b/spec/shared/repository_ext/crud.rb
@@ -55,6 +55,20 @@ RSpec.shared_examples 'repository crud' do
         expect { subject.insert(thing) }.to raise_error unique_constraint_error
       end
     end
+
+    context 'when an array of objects is provided' do
+      it 'inserts all objects' do
+        subject.insert([ Thing.new, Thing.new ])
+        expect(subject.query.count).to eq 2
+      end
+    end
+
+    context 'when objects are provided as many arguments' do
+      it 'inserts all objects' do
+        subject.insert(Thing.new, Thing.new)
+        expect(subject.query.count).to eq 2
+      end
+    end
   end
 
   describe '#update' do


### PR DESCRIPTION
The `insert` method is polysemantic. All options below are valid.

```ruby
repo.insert(object)
repo.insert([ object1, object2, object3 ])
repo.insert(object1, object2, object3)
```